### PR TITLE
Add GitHub recommended video guide and plutopy links

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -37,6 +37,12 @@ If you're a Python developer with an existing package that you think
 others would benefit from, whether you've already released it or not,
 please consider `applying <link://slug/review-process>`_ to be an Affiliated Package.
 
+If you're new to open source collaboration on GitHub, we recommend the "How to 
+Contribute to an Open Source Project on GitHub" `video guide 
+<https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github`_
+(~40 mins) or practice your first pull request on the `plutopy 
+<https://github.com/cjtu/plutopy>`_ repository (~10 mins).
+
 For more information about the PlanetaryPy Project, Michael Aye gave a 
 `talk <https://www.youtube.com/watch?v=GwvRkXpmCXc>`_ and the `slides
 <https://docs.google.com/presentation/d/1H-tGxfkSHF8vS-_rt5DQHVFmBYkJNaJW6yElUe9s2Ok/edit?usp=sharing>`_

--- a/packages/review-process/index.rst
+++ b/packages/review-process/index.rst
@@ -14,6 +14,11 @@ meant as a record of the PlanetaryPy procedure and eventually we'll
 have more detailed instructions on proposing an affiliated package,
 like `Astropy does <https://www.astropy.org/affiliated/index.html>`_.
 
+If this is your first time submitting a pull request on GitHub, 
+consider "How to Contribute to an Open Source Project on GitHub" `video guide 
+<https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github`_ 
+(~40 mins) or practice your first pull request on the `plutopy 
+<https://github.com/cjtu/plutopy>`_ repository (~10 mins).
 
 Proposing an affiliated package
 ===============================


### PR DESCRIPTION
Added links to: 

- GitHub recommended guide to pull requests [link](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
- plutopy [link](https://github.com/cjtu/plutopy)
 
as promised in the 21/07/20 planetarypy meeting https://github.com/planetarypy/TC/blob/master/Meetings/2021-07-20.md