### PR TITLE
Proposed affliated package: pdr

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -38,14 +38,15 @@
 	    "repo_url": "https://github.com/MillionConcepts/pdr",
 	    "pypi_name": "pdr",
 	    "description": "pdr, the Planetary Data Reader, is a tool which provides a single command -- read('/path/to/file') -- for ingesting all common planetary data types.",
+	    "image": null,
 	    "review": {
-	        "functionality": "To be filled out by the reviewer",
-	        "ecointegration": "To be filled out by the reviewer",
-	        "documentation": "To be filled out by the reviewer",
-	        "testing": "To be filled out by the reviewer",
-	        "devstatus": "To be filled out by the reviewer",
-	        "pythonver": "To be filled out by the reviewer",
-	        "last-updated": "To be filled out by the reviewer"
+                "functionality": "General package",
+                "ecointegration": "Good",
+                "documentation": "Good",
+                "testing": "Good",
+                "devstatus": "Good",
+                "pythonver": "3.9",
+                "last-updated": "2023-12-19"
     		}
 	},
 		{

--- a/data/registry.json
+++ b/data/registry.json
@@ -30,6 +30,24 @@
 		"pythonver": "3.6"
 	},
     "packages": [
+	    
+	    	{
+	    "name": "pdr",
+	    "maintainer": "sierra@millionconcepts.com",
+	    "home_url": "https://pdr.readthedocs.io",
+	    "repo_url": "https://github.com/MillionConcepts/pdr",
+	    "pypi_name": "pdr",
+	    "description": "pdr, the Planetary Data Reader, is a tool which provides a single command -- read('/path/to/file') -- for ingesting all common planetary data types.",
+	    "review": {
+	        "functionality": "To be filled out by the reviewer",
+	        "ecointegration": "To be filled out by the reviewer",
+	        "documentation": "To be filled out by the reviewer",
+	        "testing": "To be filled out by the reviewer",
+	        "devstatus": "To be filled out by the reviewer",
+	        "pythonver": "To be filled out by the reviewer",
+	        "last-updated": "To be filled out by the reviewer"
+    		}
+	},
 		{
             "name": "kalasiris",
             "maintainer": "rbeyer@seti.org",


### PR DESCRIPTION
The planetary data reader (pdr) has finally gotten our tests and documentation to a state for which we are ready to submit to planetarypy. pdr is under active development and continues to expand the number of datasets we have official support for; it is intended that we will read all PDS compliant data by the end of the project. Please reach out if you have any questions. Thank you for your time and consideration.