### PR TITLE
Updated Review guidelines for Python 3.9

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -27,7 +27,8 @@
     	    "functional but unmaintained": "orange",
     	    "nonfunctional": "red"
 		},
-		"pythonver": "3.6"
+		"pythonver": "3.9",
+		"pythonmaxver": "3.11"
 	},
     "packages": [
 		{
@@ -44,7 +45,7 @@
                 "documentation": "Good",
                 "testing": "Good",
                 "devstatus": "Good",
-                "pythonver": "3.6",
+                "pythonver": "3.8",
                 "last-updated": "2021-06-02"
             }
         },
@@ -62,7 +63,7 @@
                 "documentation": "Good",
                 "testing": "Good",
                 "devstatus": "Good",
-                "pythonver": "3.6",
+                "pythonver": "3.9",
                 "last-updated": "2021-01-27"
             }
         },
@@ -80,7 +81,7 @@
                 "documentation": "Good",
                 "testing": "Good",
                 "devstatus": "Good",
-                "pythonver": "3.6",
+                "pythonver": "3.9",
                 "last-updated": "2021-01-22"
             }
         }

--- a/pages/packages/index.rst
+++ b/pages/packages/index.rst
@@ -37,9 +37,14 @@ These are the PlanetaryPy Affiliated Packages:
 <%def name="getver(ver)">
 <%
     import math
+    verinfo = tuple(map(int, ver.split(".")))
+    pyver = tuple(map(int, post.data("criteria")["pythonver"].split(".")))
+    pymaxver = tuple(map(int, post.data("criteria")["pythonmaxver"].split(".")))
     try:
-        if float(ver) >= float(post.data("criteria")["pythonver"]):
+        if verinfo == pyver:
             status = f"{ver}-brightgreen"
+        elif pyver < verinfo <= pymaxver:
+            status = f"{ver}-orange"
         else:
             status = f"{ver}-red"
     except ValueError as err:

--- a/pages/packages/review-guidelines.rst
+++ b/pages/packages/review-guidelines.rst
@@ -264,18 +264,23 @@ recently-opened issues have some kind of reply from maintainers.</td>
 <h2 id="pythonver">Python version compatibility (<code>pythonver</code>)</h2>
 
 <p>
-The PlanetaryPy Project requires that packages be compatible with
+The PlanetaryPy Project encourages that packages be compatible with
 Python version ${post.data("criteria")["pythonver"]}.  Being
 compatible with later versions of Python is great, too, but must
-be compatible with at least ${post.data("criteria")["pythonver"]}.
+be compatible with at least ${post.data("criteria")["pythonver"]} to get a green
+rating, but compatibility with Python versions greater than ${post.data("criteria")["pythonver"]} and
+less than or equal to ${post.data("criteria")["pythonmaxver"]} will yield an orange rating.
 </p>
 
 <table class="table">
 <tr>
 <td class="w-25 align-center"><img src="https://img.shields.io/badge/Incompatible-red.svg" alt="Incompatible"></td>
-<td>Not compatible with Python ${post.data("criteria")["pythonver"]}.</td>
+<td>Not compatible with Python versions between ${post.data("criteria")["pythonver"]} and ${post.data("criteria")["pythonmaxver"]}.</td>
 </tr>
 <tr>
+<td class="w-25 align-center"><img src="https://img.shields.io/badge/%3E${post.data("criteria")["pythonver"]}%20%7C%20%3C%3D${post.data("criteria")["pythonmaxver"]}-orange.svg" alt="<${post.data("criteria")["pythonver"]} or >= ${post.data("criteria")["pythonmaxver"]}"></td>
+<td>Compatible with Python versions greater than ${post.data("criteria")["pythonver"]} and less than or equal to ${post.data("criteria")["pythonmaxver"]}.</td>
+</tr>
 <tr>
 <td class="w-25 align-center"><img src="https://img.shields.io/badge/${post.data("criteria")["pythonver"]}-brightgreen.svg" alt="${post.data("criteria")["pythonver"]}"></td>
 <td>Compatible with Python ${post.data("criteria")["pythonver"]}.</td>

--- a/pages/packages/review-process.rst
+++ b/pages/packages/review-process.rst
@@ -216,6 +216,7 @@ Template email with review instructions
 
    <p>Thanks!<br />
    {coordinator name}</p>
+   </div>
 
 
 Template review markdown
@@ -234,7 +235,7 @@ only the text that applies should remain, altered to your liking.
     from urllib.parse import quote
     tcase = status.title()
     encoded = quote(tcase)
-%><img src="https://img.shields.io/badge/${encoded}-${color}.alt" alt=${tcase}"></%def>
+%><img src="https://img.shields.io/badge/${encoded}-${color}.svg" alt=${tcase}"></%def>
 
 <pre class="text-monospace">
 This package has been reviewed for inclusion in the PlanetaryPy
@@ -299,6 +300,7 @@ included some comments when the score is not green.
 <tr><td><b>Python version compatibility</b></td><td>
 <a href="https://planetarypy.github.com/packages/review-guidelines#pythonver">
 ${getshield("Incompatible", "red")}
+<img src="https://img.shields.io/badge/%3E${post.data("criteria")["pythonver"]}%20%7C%20%3C%3D${post.data("criteria")["pythonmaxver"]}-orange.svg" alt="<${post.data("criteria")["pythonver"]} or >= ${post.data("criteria")["pythonmaxver"]}">
 ${getshield(post.data("criteria")["pythonver"], "brightgreen")}
 </a></td></tr>
 


### PR DESCRIPTION
Updated Review Guidelines to clearly indicate that green scores would be for Python 3.9, orange scores for Python > 3.9 and <= 3.11, and red otherwise.

Introduced new pythonmaxver into the registry to accommodate the guideline change and updated the registry indicating which existing packages meet the new criteria.

Updated the Package index page to show the right labels.

Updated the Review Process page to fix a typo and update the language.