### PR TITLE
kalasiris version update

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -64,8 +64,8 @@
                 "documentation": "Good",
                 "testing": "Good",
                 "devstatus": "Good",
-                "pythonver": "3.8",
-                "last-updated": "2021-06-02"
+                "pythonver": "3.9",
+                "last-updated": "2023-12-27"
             }
         },
         {


### PR DESCRIPTION
Verified that *kalasiris* does (and has) support Python 3.9. That is the current version that ISIS 7.20 and now 8.0.2 are pinned to.

Evidence is at this run:
https://github.com/rbeyer/kalasiris/actions/runs/7341493801/job/19989287239

Open the "Test with pytest" stage to see the runner echo the Python version:
```
Python 3.9.15
============================= test session starts ==============================
platform linux -- Python 3.9.15, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/runner/work/kalasiris/kalasiris
```